### PR TITLE
chore: release v0.0.2

### DIFF
--- a/.github/workflows/continuous-build.yaml
+++ b/.github/workflows/continuous-build.yaml
@@ -73,7 +73,6 @@ jobs:
       - name: Build with advanced feature
         run: cargo build --no-default-features --features "std-sync advanced"
 
-  
   build-esp32c3:
     name: Build for ESP32-C3 target
     runs-on: ubuntu-latest

--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -174,7 +174,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Run fmt check
         run: cargo fmt --all -- --check
-        
+
   ESP32C3_Example:
     name: Lint ESP32C3 Example
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.2](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.0.1...v0.0.2) - 2026-05-07
+
+### Added
+
+- add defmt support and esp32c3 example
+
+### Fixed
+
+- defmt feature flag
+- update examples lock
+
+### Other
+
+- add lint checks to example and library
+- add esp32 example
+
 ## [0.0.1](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.0.0...v0.0.1) - 2026-05-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsy-mk-194-rs"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 authors = ["Scott Gibb <ssmgibb@yahoo.com>"]
 description = "A Rust driver for the JSY MK-194 power monitor IC, supporting both synchronous and asynchronous operation modes."


### PR DESCRIPTION



## 🤖 New release

* `jsy-mk-194-rs`: 0.0.1 -> 0.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.0.2](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.0.1...v0.0.2) - 2026-05-07

### Added

- add defmt support and esp32c3 example

### Fixed

- defmt feature flag
- update examples lock

### Other

- add lint checks to example and library
- add esp32 example
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).