### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.1.0...v0.1.1) - 2026-05-07
+
+### Other
+
+- :art: Applied MegaLinter Changes
+
 ## [0.1.0](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.0.1...v0.1.0) - 2026-05-07
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsy-mk-194-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 authors = ["Scott Gibb <ssmgibb@yahoo.com>"]
 description = "A Rust driver for the JSY MK-194 power monitor IC, supporting both synchronous and asynchronous operation modes."


### PR DESCRIPTION



## 🤖 New release

* `jsy-mk-194-rs`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.1.0...v0.1.1) - 2026-05-07

### Other

- :art: Applied MegaLinter Changes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).