### PR TITLE
chore: release v0.1.2

### DIFF
--- a/.github/workflows/continuous-build.yaml
+++ b/.github/workflows/continuous-build.yaml
@@ -155,7 +155,7 @@ jobs:
         run: |
           cd examples/esp32c3
           cargo build
-  
+
   build-stm32f103:
     name: Build for STM32F103 target
     runs-on: ubuntu-latest
@@ -177,4 +177,3 @@ jobs:
         run: |
           cd examples/stm32f103
           cargo build
-          

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,64 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.1.1...v0.1.2) - 2026-05-10
+
+### Added
+
+- remove utils package
+- add tokio support!
+- add patch release instead of fork
+- add sync embedded-hal example for stm32
+
+### Fixed
+
+- *(examples)* registers.rs missing import
+- *(examples)* feature gating
+- *(ci)* linux gating
+- *(ci)* Add specific tool chain for stm32 example
+- *(examples)* tokio missing dep
+- *(examples)* remove toolchain
+- *(ci)* add missing build argument
+- *(ci)* actually build the MCU examples
+- tokio missing feature
+- clippy imports
+- docs test
+- tokio dep
+- reduce tokio feature set
+- reduce scope of device id
+- public modules set to private
+- remove adapter from stm32 example
+
+### Other
+
+- remove windows support
+- add stm32 build workflow
+- :art: Applied MegaLinter Changes
+- *(community)* fix wording in contributing and GitHub templates
+- *(examples)* correct grammar and improve readability
+- *(readme)* fix grammar and clarity in usage sections
+- add more readmes for examples
+- add keywords
+- add descriptions to cargo.toml
+- defmt
+- add tokio-async feature
+- add missing sections
+- add missing types
+- add function code and Error Code
+- add delay description
+- change visibility of types
+- remove unwanted unit description
+- add types description
+- add Error descriptions
+- add struct docs
+- add missing units examples
+- :art: Applied MegaLinter Changes
+- Add docs test workflow
+- add docs.rs metadata to build with std-sync feature
+- *(api)* document constructors and setter methods
+- *(getters)* add rustdoc examples for getter APIs
+- add crate-level feature flag documentation
+
 ## [0.1.1](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.1.0...v0.1.1) - 2026-05-07
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsy-mk-194-rs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 authors = ["Scott Gibb <ssmgibb@yahoo.com>"]
 description = "A Rust driver for the JSY MK-194 power monitor IC, supporting both synchronous and asynchronous operation modes."


### PR DESCRIPTION



## 🤖 New release

* `jsy-mk-194-rs`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/ScottGibb/JSY-MK-194-rs/compare/v0.1.1...v0.1.2) - 2026-05-10

### Added

- remove utils package
- add tokio support!
- add patch release instead of fork
- add sync embedded-hal example for stm32

### Fixed

- *(examples)* registers.rs missing import
- *(examples)* feature gating
- *(ci)* linux gating
- *(ci)* Add specific tool chain for stm32 example
- *(examples)* tokio missing dep
- *(examples)* remove toolchain
- *(ci)* add missing build argument
- *(ci)* actually build the MCU examples
- tokio missing feature
- clippy imports
- docs test
- tokio dep
- reduce tokio feature set
- reduce scope of device id
- public modules set to private
- remove adapter from stm32 example

### Other

- remove windows support
- add stm32 build workflow
- :art: Applied MegaLinter Changes
- *(community)* fix wording in contributing and GitHub templates
- *(examples)* correct grammar and improve readability
- *(readme)* fix grammar and clarity in usage sections
- add more readmes for examples
- add keywords
- add descriptions to cargo.toml
- defmt
- add tokio-async feature
- add missing sections
- add missing types
- add function code and Error Code
- add delay description
- change visibility of types
- remove unwanted unit description
- add types description
- add Error descriptions
- add struct docs
- add missing units examples
- :art: Applied MegaLinter Changes
- Add docs test workflow
- add docs.rs metadata to build with std-sync feature
- *(api)* document constructors and setter methods
- *(getters)* add rustdoc examples for getter APIs
- add crate-level feature flag documentation
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).